### PR TITLE
Image upload fix

### DIFF
--- a/gui/conversation.py
+++ b/gui/conversation.py
@@ -89,9 +89,13 @@ class ConversationInputView(QTextEdit):
                     logger.debug(f"Local file path: {file_path}")
                     if file_path.lower().endswith(IMAGE_FORMATS):
                         image = QImage(file_path)
+                        temp_dir = tempfile.gettempdir()
+                        file_name = self.generate_unique_filename(os.path.basename(file_path))
+                        temp_file_path = os.path.join(temp_dir, file_name)
+                        image.save(temp_file_path)
                         if not image.isNull():
-                            self.add_image_thumbnail(image, file_path)
-                            self.main_window.add_image_to_selected_thread(file_path)
+                            self.add_image_thumbnail(image, temp_file_path)
+                            self.main_window.add_image_to_selected_thread(temp_file_path)
                         else:
                             logger.error(f"Could not load image from file: {file_path}")
                     else:

--- a/gui/conversation.py
+++ b/gui/conversation.py
@@ -315,12 +315,12 @@ class ConversationView(QWidget):
                 self.append_message(message.sender, text_message.content, color=color)
 
             # Handle file message content
-            if message.file_message:
-                file_message = message.file_message
+            if len(message.file_messages) > 0:
+                for file_message in message.file_messages:
                 # Synchronously retrieve and process the file
-                file_path = file_message.retrieve_file(self.file_path)
-                if file_path:
-                    self.append_message(message.sender, f"File saved: {file_path}", color='green')
+                    file_path = file_message.retrieve_file(self.file_path)
+                    if file_path:
+                        self.append_message(message.sender, f"File saved: {file_path}", color='green')
 
             # Handle image message content
             if len(message.image_messages) > 0:

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -594,7 +594,7 @@ class MainWindow(QMainWindow, AssistantClientCallbacks, TaskManagerCallbacks):
         for message in conversation.messages:
             if len(message.file_messages) > 0:
                 for file_message in message.file_messages:
-                    file_path = message.file_message.retrieve_file(assistant_config.output_folder_path)
+                    file_path = file_message.retrieve_file(assistant_config.output_folder_path)
                     logger.debug(f"File downloaded to {file_path} on run end")
 
     # Callbacks for TaskManagerCallbacks

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -437,7 +437,7 @@ class MainWindow(QMainWindow, AssistantClientCallbacks, TaskManagerCallbacks):
         attachments = [
             Attachment.from_dict(att_dict) 
             for att_dict in attachments_dicts 
-            if not conversation.contains_image_file_id(att_dict["file_id"])
+            if not conversation.contains_file_id(att_dict["file_id"])
         ]
         thread_client.create_conversation_thread_message(
             user_input, thread_name, 

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -592,9 +592,10 @@ class MainWindow(QMainWindow, AssistantClientCallbacks, TaskManagerCallbacks):
 
         # copy files from conversation to output folder at the end of the run
         for message in conversation.messages:
-            if message.file_message:
-                file_path = message.file_message.retrieve_file(assistant_config.output_folder_path)
-                logger.debug(f"File downloaded to {file_path} on run end")
+            if len(message.file_messages) > 0:
+                for file_message in message.file_messages:
+                    file_path = message.file_message.retrieve_file(assistant_config.output_folder_path)
+                    logger.debug(f"File downloaded to {file_path} on run end")
 
     # Callbacks for TaskManagerCallbacks
     def on_task_started(self, task: Task, schedule_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Assistant middleware from GitHub Release
-https://github.com/Azure-Samples/azureai-assistant-tool/releases/download/v0.4.0-alpha/azure_ai_assistant-0.4.0a1-py3-none-any.whl
+https://github.com/Azure-Samples/azureai-assistant-tool/releases/download/v0.4.4-alpha/azure_ai_assistant-0.4.4a1-py3-none-any.whl
 
 # GUI Framework
 PySide6

--- a/sdk/azure-ai-assistant/azure/ai/assistant/_version.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "0.4.2a1"
+VERSION = "0.4.4a1"

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/async_chat_assistant_client.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/async_chat_assistant_client.py
@@ -231,7 +231,7 @@ class AsyncChatAssistantClient(BaseChatAssistantClient):
                 temperature = None if text_completion_config is None else text_completion_config.temperature
                 seed = None if text_completion_config is None else text_completion_config.seed
                 frequency_penalty = None if text_completion_config is None else text_completion_config.frequency_penalty
-                max_tokens = None if text_completion_config is None else text_completion_config.max_tokens
+                max_tokens = 1000 if text_completion_config is None else text_completion_config.max_tokens
                 presence_penalty = None if text_completion_config is None else text_completion_config.presence_penalty
                 top_p = None if text_completion_config is None else text_completion_config.top_p
                 response_format = None if text_completion_config is None else {'type': text_completion_config.response_format}

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/async_conversation.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/async_conversation.py
@@ -96,13 +96,14 @@ class AsyncConversation:
                 return message.text_message
         return None
     
-    def contains_image_file_id(self, file_id: str) -> bool:
+    def contains_file_id(self, file_id: str) -> bool:
         """
-        Checks if the list of image messages contains a specific file ID.
-
+        Checks if the list of file messages contains a specific file ID.
         :param file_id: The file ID to check.
         :type file_id: str
         :return: True if the file ID is found, False otherwise.
         :rtype: bool
         """
-        return any(image_message.file_id == file_id for message in self.messages for image_message in message.image_messages if image_message is not None)
+        image_files_contains = any(image_message.file_id == file_id for message in self.messages for image_message in message.image_messages if image_message is not None)
+        files_contains = any(file_message.file_id == file_id for message in self.messages for file_message in message.file_messages if file_message is not None)
+        return image_files_contains or files_contains

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/async_conversation_thread_client.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/async_conversation_thread_client.py
@@ -332,7 +332,6 @@ class AsyncConversationThreadClient:
                     else:  # Tool file
                         all_updated_attachments.append(current_attachment)
 
-            self._thread_config.set_attachments_of_thread(thread_id, all_updated_attachments + image_attachments)
             updated_attachments = [{'file_id': att.file_id, 'tools': [att.tool.to_dict()] if att.tool else []} for att in all_updated_attachments]
             return updated_attachments, image_attachments
         except Exception as e:

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/async_message.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/async_message.py
@@ -28,7 +28,7 @@ class AsyncConversationMessage:
         self._ai_client : Union[AsyncOpenAI, AsyncAzureOpenAI] = None
         self._original_message = None
         self._text_message = None
-        self._file_message = None
+        self._file_messages = []
         self._image_messages = []
         self._image_urls = []
         self._role = None
@@ -100,7 +100,8 @@ class AsyncConversationMessage:
                 if isinstance(annotation, FilePathAnnotation):
                     file_id = annotation.file_path.file_id
                     file_name = annotation.text.split("/")[-1]
-                    self._file_message = await AsyncFileMessage.create(self._ai_client, file_id, file_name)
+                    file_message = await AsyncFileMessage.create(self._ai_client, file_id, file_name)
+                    self._file_messages.append(file_message)
                     citations.append(f'[{index}] {file_name}')
                     file_citations.append(FileCitation(file_id, file_name))
 
@@ -138,14 +139,14 @@ class AsyncConversationMessage:
         self._text_message = value
 
     @property
-    def file_message(self) -> Optional['AsyncFileMessage']:
+    def file_messages(self) -> Optional['AsyncFileMessage']:
         """
         Returns the file message content of the conversation message.
 
         :return: The file message content of the conversation message.
         :rtype: Optional[AsyncFileMessage]
         """
-        return self._file_message
+        return self._file_messages
 
     @property
     def image_messages(self) -> List['AsyncImageMessage']:

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/async_message.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/async_message.py
@@ -139,12 +139,12 @@ class AsyncConversationMessage:
         self._text_message = value
 
     @property
-    def file_messages(self) -> Optional['AsyncFileMessage']:
+    def file_messages(self) -> List['AsyncFileMessage']:
         """
         Returns the file message content of the conversation message.
 
         :return: The file message content of the conversation message.
-        :rtype: Optional[AsyncFileMessage]
+        :rtype: List[AsyncFileMessage]
         """
         return self._file_messages
 

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/chat_assistant_client.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/chat_assistant_client.py
@@ -213,7 +213,7 @@ class ChatAssistantClient(BaseChatAssistantClient):
                 temperature = None if text_completion_config is None else text_completion_config.temperature
                 seed = None if text_completion_config is None else text_completion_config.seed
                 frequency_penalty = None if text_completion_config is None else text_completion_config.frequency_penalty
-                max_tokens = None if text_completion_config is None else text_completion_config.max_tokens
+                max_tokens = 1000 if text_completion_config is None else text_completion_config.max_tokens
                 presence_penalty = None if text_completion_config is None else text_completion_config.presence_penalty
                 top_p = None if text_completion_config is None else text_completion_config.top_p
                 response_format = None if text_completion_config is None else {'type': text_completion_config.response_format}

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/conversation.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/conversation.py
@@ -82,13 +82,15 @@ class Conversation:
                 return message.text_message
         return None
     
-    def contains_image_file_id(self, file_id: str) -> bool:
+    def contains_file_id(self, file_id: str) -> bool:
         """
-        Checks if the list of image messages contains a specific file ID.
+        Checks if the list of file messages contains a specific file ID.
 
         :param file_id: The file ID to check.
         :type file_id: str
         :return: True if the file ID is found, False otherwise.
         :rtype: bool
         """
-        return any(image_message.file_id == file_id for message in self.messages for image_message in message.image_messages if image_message is not None)
+        image_files_contains = any(image_message.file_id == file_id for message in self.messages for image_message in message.image_messages if image_message is not None)
+        files_contains = any(file_message.file_id == file_id for message in self.messages for file_message in message.file_messages if file_message is not None)
+        return image_files_contains or files_contains

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/conversation_thread_client.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/conversation_thread_client.py
@@ -329,7 +329,6 @@ class ConversationThreadClient:
                     else:  # Tool file
                         all_updated_attachments.append(current_attachment)
 
-            self._thread_config.set_attachments_of_thread(thread_id, all_updated_attachments + image_attachments)
             updated_attachments = [{'file_id': att.file_id, 'tools': [att.tool.to_dict()] if att.tool else []} for att in all_updated_attachments]
             return updated_attachments, image_attachments
         except Exception as e:

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/message.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/message.py
@@ -122,12 +122,12 @@ class ConversationMessage:
         self._text_message = value
 
     @property
-    def file_messages(self) -> Optional['FileMessage']:
+    def file_messages(self) -> List['FileMessage']:
         """
         Returns the file message content.
 
         :return: The file message content.
-        :rtype: Optional[FileMessage]
+        :rtype: List[FileMessage]
         """
         return self._file_messages
 

--- a/sdk/azure-ai-assistant/azure/ai/assistant/management/message.py
+++ b/sdk/azure-ai-assistant/azure/ai/assistant/management/message.py
@@ -36,7 +36,7 @@ class ConversationMessage:
         self._ai_client = ai_client
         self._original_message = original_message
         self._text_message = None
-        self._file_message = None
+        self._file_messages = []
         self._image_messages = []
         self._image_urls = []
         self._role = original_message.role if original_message else "assistant"
@@ -85,7 +85,7 @@ class ConversationMessage:
                 if isinstance(annotation, FilePathAnnotation):
                     file_id = annotation.file_path.file_id
                     file_name = annotation.text.split("/")[-1]
-                    self._file_message = FileMessage(self._ai_client, file_id, file_name)
+                    self._file_messages.append(FileMessage(self._ai_client, file_id, file_name))
                     citations.append(f'[{index}] {file_name}')
                     file_citations.append(FileCitation(file_id, file_name))
 
@@ -122,14 +122,14 @@ class ConversationMessage:
         self._text_message = value
 
     @property
-    def file_message(self) -> Optional['FileMessage']:
+    def file_messages(self) -> Optional['FileMessage']:
         """
         Returns the file message content.
 
         :return: The file message content.
         :rtype: Optional[FileMessage]
         """
-        return self._file_message
+        return self._file_messages
 
     @property
     def image_messages(self) -> List['ImageMessage']:

--- a/sdk/azure-ai-assistant/test/test_assistant_client.py
+++ b/sdk/azure-ai-assistant/test/test_assistant_client.py
@@ -261,9 +261,9 @@ def test_assistant_client_create_thread_and_process_message_with_multi_image():
     assert last_message.image_messages is not None
     assert len(last_message.image_messages) == 2
     assert last_message.image_messages[0].file_id is not None
-    assert conversation.contains_image_file_id(last_message.image_messages[0].file_id)
+    assert conversation.contains_file_id(last_message.image_messages[0].file_id)
     assert last_message.image_messages[1].file_id is not None
-    assert conversation.contains_image_file_id(last_message.image_messages[1].file_id)
+    assert conversation.contains_file_id(last_message.image_messages[1].file_id)
     
     client.purge()
 
@@ -287,8 +287,8 @@ def test_assistant_client_create_thread_and_process_multi_messages_with_image():
     assert last_message.image_messages is not None
     assert len(last_message.image_messages) == 2
     assert last_message.image_messages[0].file_id is not None
-    assert conversation.contains_image_file_id(last_message.image_messages[0].file_id)
+    assert conversation.contains_file_id(last_message.image_messages[0].file_id)
     assert last_message.image_messages[1].file_id is not None
-    assert conversation.contains_image_file_id(last_message.image_messages[1].file_id)
+    assert conversation.contains_file_id(last_message.image_messages[1].file_id)
     
     client.purge()

--- a/sdk/azure-ai-assistant/test/test_async_assistant_client.py
+++ b/sdk/azure-ai-assistant/test/test_async_assistant_client.py
@@ -140,9 +140,9 @@ async def test_assistant_client_create_thread_and_process_message_with_multi_ima
     assert last_message.image_messages is not None
     assert len(last_message.image_messages) == 2
     assert last_message.image_messages[0].file_id is not None
-    assert conversation.contains_image_file_id(last_message.image_messages[0].file_id)
+    assert conversation.contains_file_id(last_message.image_messages[0].file_id)
     assert last_message.image_messages[1].file_id is not None
-    assert conversation.contains_image_file_id(last_message.image_messages[1].file_id)
+    assert conversation.contains_file_id(last_message.image_messages[1].file_id)
     
     await client.purge()
     await thread_client.close()
@@ -168,9 +168,9 @@ async def test_assistant_client_create_thread_and_process_multi_messages_with_im
     assert last_message.image_messages is not None
     assert len(last_message.image_messages) == 2
     assert last_message.image_messages[0].file_id is not None
-    assert conversation.contains_image_file_id(last_message.image_messages[0].file_id)
+    assert conversation.contains_file_id(last_message.image_messages[0].file_id)
     assert last_message.image_messages[1].file_id is not None
-    assert conversation.contains_image_file_id(last_message.image_messages[1].file_id)
+    assert conversation.contains_file_id(last_message.image_messages[1].file_id)
     
     await client.purge()
     await thread_client.close()

--- a/templates/multi_template.py
+++ b/templates/multi_template.py
@@ -45,12 +45,14 @@ class MultiAgentOrchestrator(TaskManagerCallbacks, AssistantClientCallbacks):
                 if message.text_message:
                     if message.sender == assistant_name:
                         print(f"{message.sender}: {message.text_message.content}")
-                if message.file_message:
-                    print(f"{message.sender}: provided file {message.file_message.file_name}")
-                    message.file_message.retrieve_file(assistant_client.assistant_config.output_folder_path)
-                if message.image_message:
-                    print(f"{message.sender}: provided image {message.image_message.file_name}")
-                    message.image_message.retrieve_image(assistant_client.assistant_config.output_folder_path)
+                if len(message.file_messages) > 0:
+                    for file_message in message.file_messages:
+                        print(f"{message.sender}: provided file {file_message.file_name}")
+                        file_message.retrieve_file(assistant_client.assistant_config.output_folder_path)
+                if len(message.image_messages) > 0:
+                    for image_message in message.image_messages:
+                        print(f"{message.sender}: provided image {image_message.file_name}")
+                        image_message.retrieve_image(assistant_client.assistant_config.output_folder_path)
 
     def on_task_completed(self, task : MultiTask, schedule_id, result):
         print(f"Task {task.id} completed with schedule ID: {schedule_id}. Result: {result}")


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Changed ConversationThreadClient so that old image files are kept on thread
* Change ConversationMessage and AsyncConversationMessage classes to support multiple FileMessage instances per instance
* Change max tokens default value to 1000
* Add contains_file_id method and remove contains_image_file_id from Conversation and AsyncConversation classes
* Fixed issue where image uploaded in chat is appended to every subsequent message
* Fixed issue where images uploaded with same file path would all be deleted
* Version updated to 0.4.4-alpha

## Does this introduce a breaking change?
The file_message property of the Message and AsyncMessage classes has been changed to file_messages and now returns a list of FileMessage objects. To go through individual file messages you can iterate through file_messages.

The contains_image_file_id method has been removed from the Conversation and AsyncConversation classes. To check if a conversation contains any file with the specified file id, use the new contains_file_id method
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Use GUI

## Other Information
<!-- Add any other helpful information that may be needed here. -->